### PR TITLE
Fix XR controller hand mapping

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -534,13 +534,13 @@ class RealSteelARGame {
                 relativeCamera.z *= -1;
             }
 
-            const target = i === 0 ? this.rightHandTarget : this.leftHandTarget;
+            const target = i === 0 ? this.leftHandTarget : this.rightHandTarget;
             target.copy(relativeCamera);
 
             if (i === 0) {
-                target.x = THREE.MathUtils.clamp(target.x, -0.2, 0.8);
-            } else {
                 target.x = THREE.MathUtils.clamp(target.x, -0.8, 0.2);
+            } else {
+                target.x = THREE.MathUtils.clamp(target.x, -0.2, 0.8);
             }
 
             target.y = THREE.MathUtils.clamp(target.y, 0.3, 1.6);


### PR DESCRIPTION
## Summary
- map controller index 0 to the left hand target and index 1 to the right
- swap horizontal clamp ranges so each hand stays on its correct side of the robot

## Testing
- not run (WebXR session not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da6bd1e9e8832e9162018a2e847e53