### PR TITLE
Fix shoulder position usage in arm IK

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -565,6 +565,8 @@ class RealSteelARGame {
         const elbow = arm.userData.elbow;
         const shoulder = arm.userData.shoulder;
 
+        const shoulderPos = shoulder.position.clone();
+
         // Get current hand position relative to robot
         const currentHandPos = hand.position.clone();
 
@@ -586,7 +588,6 @@ class RealSteelARGame {
         }
 
         // Two-bone IK calculation
-        const shoulderPos = shoulder.position.clone();
         const upperArmLength = 0.3;
         const forearmLength = 0.25;
         const totalArmLength = upperArmLength + forearmLength;


### PR DESCRIPTION
## Summary
- define the shoulder position clone before IK calculations that rely on it
- ensure arm IK calculations reuse the stored shoulder position value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da6c3a0a2c832eb5cb0ac2c660587b